### PR TITLE
Execute perltidy in workspace.rootPath

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -42,7 +42,9 @@ export class PerlFormattingProvider implements vscode.DocumentRangeFormattingEdi
             }
 
             let text = document.getText(range);
-            let child = cp.spawn(executable, args);
+            let child = cp.spawn(executable, args, {
+                cwd: vscode.workspace.rootPath
+            });
             child.stdin.write(text);
             child.stdin.end();
 


### PR DESCRIPTION
This allows for `.perltidyrc` to be a part of the repository
CWD without this modification is `/` (on macOS) and I have not found a way to put a variable in the perltidyArgs

This configuration would then pick up `.perltidyrc` from the root of the project/repository.
```json
"perl.perltidyArgs": [
    "-pro=.perltidyrc"
],
```