### PR TITLE
Fixed a bug about 'go to definition'

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export function getPackageBefore(document: vscode.TextDocument, range: vscode.Ra
     let separator = document.getText(separatorRange);
     let pkg = "";
 
-    while (separator === "::") {
+    while (separator === "::" || separator === "->") {
         const newRange = document.getWordRangeAtPosition(getPointBefore(separatorRange, 1));
         if (newRange) {
             range = newRange;
@@ -30,7 +30,7 @@ export function getPackageBefore(document: vscode.TextDocument, range: vscode.Ra
         }
     }
 
-    return pkg.replace(/::$/, "");
+    return pkg.replace(/(::|->)$/, "");
 }
 
 export function getMatchLocation(line: string, rootPath?: string): vscode.Location {


### PR DESCRIPTION
When the function with the same name is in multiple packages, the function does not jump to the correct definition source.
Because the function doesn't lookup string before `->`.
So I added separator `->`.

This p-r is my first p-r to OSS, moreover my English is poor.
Sorry if I made some mistake.
