### PR TITLE
Fixes Workspace Symbols only showing half of the symbols.

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -64,7 +64,7 @@ export class PerlSymbolProvider implements vscode.DocumentSymbolProvider,
     }
 
     var validSymbols: vscode.SymbolInformation[] = [];
-    let regxQuery = new RegExp(query.split('').join('.*?'), 'gi');
+    let regxQuery = new RegExp(query.split('').join('.*?'), 'i');
     let projectTags = await this.tags.readProjectTags();
     for (const tags of projectTags) {
       if (tags instanceof Error) {


### PR DESCRIPTION
Fixes Workspace Symbols only showing half of the symbols by removing the 'global' flag, so that it doesn't preserve the lastIndex of the previous search.